### PR TITLE
Fix CSS and styling after Next.js migration

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
 	},
 	"devDependencies": {
 		"@biomejs/biome": "^1.9.4",
+		"@tailwindcss/postcss": "^4.1.17",
 		"@types/node": "^22.10.2",
 		"@types/react": "^19.0.2",
 		"@types/react-dom": "^19.0.2",

--- a/postcss.config.mjs
+++ b/postcss.config.mjs
@@ -1,0 +1,5 @@
+export default {
+	plugins: {
+		"@tailwindcss/postcss": {},
+	},
+};


### PR DESCRIPTION
The app's CSS was broken on Vercel because Tailwind v4's @apply directives were not being processed. This happened because Tailwind v4 uses a new CSS-first configuration approach that requires the @tailwindcss/postcss plugin to transform CSS directives.

Changes:
- Added postcss.config.mjs with @tailwindcss/postcss plugin
- Installed @tailwindcss/postcss package (v4.x compatible)
- Verified CSS is now properly compiled (tested @apply directives)

This fixes the broken styling on production deployments.